### PR TITLE
Revert "add google analytics tag to hugo.toml"

### DIFF
--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -3,9 +3,6 @@ languageCode = 'en-us'
 title = 'Konflux'
 theme = ['konflux', 'github.com/devcows/hugo-universal-theme']
 
-# Enable Google Analytics by entering your tracking code
-googleAnalytics = "G-381LYFWTP4"
-
 # Site language. Available translations in the theme's `/i18n` directory.
 defaultContentLanguage = "en"
 


### PR DESCRIPTION
This reverts commit d63c1a6fe2196b0d1f87990e5a3cd510711055fa.

Reverting because we don't need to send analytics data to Brian's account any more.