### PR TITLE
Revert "Prepare move to a .org domain"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # konflux-ci.github.io
 
 This repository contains the source code for the konflux-ci website hosted at
-[konflux-ci.org](https://konflux-ci.org/).
+[konflux-ci.dev](https://konflux-ci.dev/).
 
 The website is based on [Hugo](https://gohugo.io/) and
 [hugo-universal-theme](https://github.com/devcows/hugo-universal-theme).
@@ -11,7 +11,7 @@ The website is based on [Hugo](https://gohugo.io/) and
 When new code is pushed to the repository's `main` branch, it triggers a GitHub action
 that renders the website HTML and CSS files using Hugo, and pushes those artifacts to
 the repository's GitHub Page which is reachable at
-[konflux-ci.org](https://konflux-ci.org/).
+[konflux-ci.dev](https://konflux-ci.dev/).
 
 See more details here:
 https://gohugo.io/hosting-and-deployment/hosting-on-github/

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://konflux-ci.org/'
+baseURL = 'https://konflux-ci.dev/'
 languageCode = 'en-us'
 title = 'Konflux'
 theme = ['konflux', 'github.com/devcows/hugo-universal-theme']
@@ -28,7 +28,7 @@ pluralizelisttitles = false
 [[menu.main]]
     name       = "User Guide"
     identifier = "menu.userguide"
-    url        = "https://konflux-ci.org/docs"
+    url        = "https://konflux-ci.dev/docs"
     weight     = 2
 
 [params.carouselHomepage]


### PR DESCRIPTION
Reverts konflux-ci/konflux-ci.github.io#43

We have konflux-ci.dev again so let's move back to what it used to be in order to maintain the history of links that anyone might have had in the past.