### PR TITLE
fix(KFLUXUI-1286): restore TSF card and update Try Konflux copy

### DIFF
--- a/data/try-konflux.yaml
+++ b/data/try-konflux.yaml
@@ -41,13 +41,13 @@ tsfSection:
   badge: "Dev Preview"
   badgeColor: "orangered"
   title: "Trusted Software Factory"
-  description: "Opinionated framework combining Konflux with additional Red Hat security and compliance tools. Automates GitHub and Quay integration with guided setup."
+  description: "Opinionated framework combining Konflux with additional Red Hat security and compliance tools. Automates GitHub, GitLab and Quay integration with guided setup."
   features:
     - "OpenShift 4.20+ with admin access required"
-    - "Automated GitHub and Quay integration"
+    - "Automated GitHub, GitLab and Quay integration"
     - "Red Hat opinionated security setup"
   note: "TSF is a separate project that uses Konflux. For standalone Konflux installations, use the guides above."
   link:
     label: "Explore TSF Documentation"
-    href: "https://github.com/redhat-appstudio/tsf-cli/blob/main/docs/trusted-software-factory.md"
+    href: "https://redhat-appstudio.github.io/tsf-cli/tsf/index.html"
     icon: "ExternalLinkAltIcon"

--- a/src/components/TryKonfluxPage.tsx
+++ b/src/components/TryKonfluxPage.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { PageSection, Flex, Gallery } from "@patternfly/react-core";
+import { PageSection, Flex, FlexItem, Gallery } from "@patternfly/react-core";
 import type { TryKonfluxData } from "@site/src/types/content";
 import SectionHeader from "@site/src/components/ui/SectionHeader";
 import OptionCard from "@site/src/components/ui/OptionCard";
@@ -41,6 +41,10 @@ export default function TryKonfluxPage({
             <OptionCard key={option.title} option={option} />
           ))}
         </Gallery>
+
+        <FlexItem style={{ marginBlockStart: "var(--pf-t--global--spacer--md)" }}>
+          <OptionCard option={data.tsfSection} variant="preview" />
+        </FlexItem>
       </Flex>
     </PageSection>
   );


### PR DESCRIPTION
## Description

Restores the Trusted Software Factory (TSF) preview card on the Try Konflux page after approval to publish the documentation link. The card was hidden in #61 (KFLUXUI-1179); this brings it back and updates TSF copy to include GitLab and points the docs CTA to the published Antora site.

## Fixes

Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1286

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Requires documentation update

## Screen shots / Gifs
<img width="1209" height="756" alt="image" src="https://github.com/user-attachments/assets/06d44c16-94f2-470e-b9b1-7e0299a77087" />


<!-- UI: `/try-konflux` shows TSF Dev Preview card with updated GitLab wording and doc link. Add a screenshot if helpful for reviewers. -->

## How to test or reproduce

1. Run `yarn start` and open `/try-konflux`.
2. Confirm the TSF "Dev Preview" card appears below the two installation option cards.
3. Confirm the feature list includes "Automated GitHub, GitLab and Quay integration".
4. Click "Explore TSF Documentation" and confirm it opens https://redhat-appstudio.github.io/tsf-cli/tsf/index.html.

## Browser conformance

- [ ] Desktop Chrome
- [ ] Desktop Firefox
- [ ] Desktop Safari
